### PR TITLE
3.0.0 did not build for me anymore, thus moved forward to 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,17 @@ RUN \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN \
-  wget https://codeload.github.com/google/protobuf/tar.gz/v3.0.0-beta-3 && \
-  tar xvzf v3.0.0-beta-3 && \
-  rm v3.0.0-beta-3 && \
-  cd protobuf-3.0.0-beta-3 && \
+  wget https://codeload.github.com/google/protobuf/tar.gz/v3.2.0 && \
+  tar xvzf v3.2.0 && \
+  rm v3.2.0 && \
+  cd protobuf-3.2.0 && \
   ./autogen.sh && \
   ./configure --prefix=/usr && \
   make && \
   make check && \
   make install && \
   cd - && \
-  rm -rf protobuf-3.0.0-beta-3
+  rm -rf protobuf-3.2.0
 
 RUN \
   git clone https://github.com/grpc/grpc.git && \


### PR DESCRIPTION
The 3.0.0 container did not build for me anymore, thus I created a PR to update.
However - I don't know the impact of this across our system, thus I'll create another PR to fix the 3.0.0 build.